### PR TITLE
Added ContrastiveExplanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If you want to contribute to this list (*and please do!*) read over the [contrib
 
 * [aequitas](https://github.com/dssg/aequitas)
 * [anchor](https://github.com/marcotcr/anchor)
+* [ContrastiveExplanation (Foil Trees)](https://github.com/MarcelRobeer/ContrastiveExplanation)
 * [eli5](https://github.com/TeamHG-Memex/eli5)
 * [fairml](https://github.com/adebayoj/fairml)
 * [lime](https://github.com/marcotcr/lime)


### PR DESCRIPTION
Added **Contrastive Explanation** (Foil Trees), presented at WHI 2018 ([https://arxiv.org/abs/1806.07470](https://arxiv.org/abs/1806.07470))