### PR TITLE
added saliency maps for deep learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ If you want to contribute to this list (*and please do!*) read over the [contrib
   * [Model Interpretation Strategies](https://towardsdatascience.com/explainable-artificial-intelligence-part-2-model-interpretation-strategies-75d4afa6b739)
   * [Hands-on Machine Learning Model Interpretation](https://towardsdatascience.com/explainable-artificial-intelligence-part-3-hands-on-machine-learning-model-interpretation-e8ebe5afc608)
 * [Partial Dependence Plots in R](https://journal.r-project.org/archive/2017/RJ-2017-016/)
+* [Saliency Maps for Deep
+  Learning](https://medium.com/@thelastalias/saliency-maps-for-deep-learning-part-1-vanilla-gradient-1d0665de3284)
 * [Visualizing ML Models with LIME](http://uc-r.github.io/lime)
 
 ## Explainability- or Fairness-Enhancing Software Packages


### PR DESCRIPTION
Adds a tutorial I wrote on saliency maps.

https://medium.com/@thelastalias/saliency-maps-for-deep-learning-part-1-vanilla-gradient-1d0665de3284

![image](https://user-images.githubusercontent.com/1892071/64287257-0879b400-cf14-11e9-9409-83b4df4cb0a3.png)
