### PR TITLE
Add Distill

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ If you want to contribute to this list (*and please do!*) read over the [contrib
 * [criticalML](https://github.com/rockita/criticalML)
 * [Debugging Machine Learning Models (ICLR workshop proceedings)](https://debug-ml-iclr2019.github.io/)
 * [Deep Insights into Explainability and Interpretability of Machine Learning Algorithms and Applications to Risk Management](https://ww2.amstat.org/meetings/jsm/2019/onlineprogram/AbstractDetails.cfm?abstractid=303053)
+* [Distill](https://distill.pub) 
 * [Fairness, Accountability, and Transparency in Machine Learning (FAT/ML) Scholarship](https://www.fatml.org/resources/relevant-scholarship)
 * [Machine Learning Ethics References](https://github.com/radames/Machine-Learning-Ethics-References)
 * [Machine Learning Interpretability Resources](https://github.com/h2oai/mli-resources)


### PR DESCRIPTION
Add Distil Pub

distill.pub - "This is an attempt to modernize the main issues we face with the traditional printed scientific papers in computer science and machine learning which now more than ever involve an overabundant amount of data and are nearly impossible to understand on a sheet of paper. Distill.pub brings clarity, reproducibility, and interactivity. PDF files are from another age. distill.pub is an expression of our time." 