### PR TITLE
Add PySS3

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ If you want to contribute to this list (*and please do!*) read over the [contrib
 * [Optimal Sparse Decision Trees](https://github.com/xiyanghu/OSDT)
 * [Monotonic](http://xgboost.readthedocs.io/en/latest/tutorials/monotonic.html) [XGBoost](http://xgboost.readthedocs.io/en/latest/)
 * [pyGAM](https://github.com/dswah/pyGAM)
+* [pySS3](https://github.com/sergioburdisso/pyss3)
 * [Risk-SLIM](https://github.com/ustunb/risk-SLIM)
 * Scikit-learn
   * [Decision Trees](http://scikit-learn.org/stable/modules/tree.html)


### PR DESCRIPTION
PySS3 is an open-source python package that implements a novel white-box machine learning model (SS3) for text classification. In addition, PySS3 comes with a set of visualizations tools for Explainable Artificial Intelligence (XAI).

Github repo: [https://github.com/sergioburdisso/pyss3](https://github.com/sergioburdisso/pyss3)
Online live demos: [http://tworld.io/ss3/](http://tworld.io/ss3/)
Documentation: [https://pyss3.readthedocs.io](https://pyss3.readthedocs.io)
Paper preprint: [https://arxiv.org/abs/1912.09322](https://arxiv.org/abs/1912.09322)

Since I've put a lot of work on this project I know that my opinion could be really really skewed, but I believe that PySS3 deserves a shot... check it out guys... I hope you guys find it ![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg) enough.