### PR TITLE
add model agnostic XAI python package and a free XAI book for software engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ If you want to contribute to this list (*and please do!*) read over the [contrib
 * [PDPbox](https://github.com/SauceCat/PDPbox)
 * [pyBreakDown](https://github.com/MI2DataLab/pyBreakDown)
 * [PyCEbox](https://github.com/AustinRochford/PyCEbox)
+* [PyExplainer](https://github.com/awsm-research/PyExplainer)
 * [pyGAM](https://github.com/dswah/pyGAM)
 * [pymc3](https://github.com/pymc-devs/pymc3)
 * [pytorch-innvestigate](https://github.com/fgxaos/pytorch-innvestigate)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ If you want to contribute to this list (*and please do!*) read over the [contrib
 ## Free Books
 
 * [An Introduction to Machine Learning Interpretability](https://www.h2o.ai/wp-content/uploads/2019/08/An-Introduction-to-Machine-Learning-Interpretability-Second-Edition.pdf)
+* [Explainable AI for Software Engineering](https://xai4se.github.io/)
 * [Explanatory Model Analysis](https://pbiecek.github.io/ema/)
 * [Fairness and Machine Learning](http://fairmlbook.org/)
 * [Interpretable Machine Learning](https://christophm.github.io/interpretable-ml-book/)


### PR DESCRIPTION
The link to the repository of PyExplainer: https://github.com/awsm-research/PyExplainer
The link to the corresponding conference paper of PyExplainer: https://www.researchgate.net/publication/354326426_PyExplainer_Explaining_the_Predictions_of_Just-In-Time_Defect_Models

The link to the free XAI book for Software Engineering: https://xai4se.github.io/