### PR TITLE
Add Chain of Thought to Podcasts and Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1620,7 +1620,7 @@ This section features a selection of educational courses focused on ethical cons
 
 This section features podcasts and channels (such as on YouTube) that offer insightful commentary and explanations on responsible AI and machine learning interpretability.
 
-* [Chain of Thought](https://www.chainofthought.dev/)
+* [Chain of Thought](https://chainofthought.show/)
 * [Internet of Bugs](https://www.youtube.com/@InternetOfBugs/videos)
 * [Tech Won't Save Us](https://techwontsave.us/)
 * [This Is Technology Ethics: An Introduction](https://technologyethicspod.wordpress.com/)

--- a/README.md
+++ b/README.md
@@ -1620,6 +1620,7 @@ This section features a selection of educational courses focused on ethical cons
 
 This section features podcasts and channels (such as on YouTube) that offer insightful commentary and explanations on responsible AI and machine learning interpretability.
 
+* [Chain of Thought](https://www.chainofthought.dev/)
 * [Internet of Bugs](https://www.youtube.com/@InternetOfBugs/videos)
 * [Tech Won't Save Us](https://techwontsave.us/)
 * [This Is Technology Ethics: An Introduction](https://technologyethicspod.wordpress.com/)


### PR DESCRIPTION
Adding [Chain of Thought](https://chainofthought.show/) to the Podcasts and Channels section.

Chain of Thought is a weekly podcast hosted by Conor Bronsdon featuring conversations with AI leaders and engineers. Episodes regularly cover responsible AI, model interpretability, AI safety, and the societal implications of AI systems.

- Website: https://chainofthought.show/
- Available on Apple Podcasts, Spotify, YouTube